### PR TITLE
Fix Tor control password setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ RPC_PASSWORD=your_rpc_password
 
 # Tor control credentials used internally
 TOR_CONTROL_PASSWORD=your_tor_control_password
-TOR_CONTROL_HASHED_PASSWORD=16:ADDBD7CF108C995F60F831F115BA5EB95322FC4645433CDEB8948A57DF
 ```
 
 WARNING: *if you already have tor installed on your system, make sure that your TOR_DATA directory is not the same as the one already used by your system tor installation. One is used inside the containers, the other is used by your system tor service.*
 
 WARNING: *if you plan to run the node for multiple sessions, make sure that the HOST_PUBLIC_IP is up to date with the current public IP of your host machine. It is strongly recommended to use a static IP*
+
+The Tor control password is used by Knots to ask Tor to create the node's onion
+service. The Tor client container derives the hashed control password from
+`TOR_CONTROL_PASSWORD` at startup, so the hash cannot drift from the value passed
+to Knots.
 
 3. Build the Docker images:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       dockerfile: Dockerfile
       # args:
     container_name: tor-client
-    # environment:
+    environment:
+      TOR_CONTROL_PASSWORD: ${TOR_CONTROL_PASSWORD}
     volumes:
       - ${TOR_DATA}:/var/lib/tor:rw
     # secrets:
@@ -19,7 +20,6 @@ services:
     restart: always
     init: true
     user: ${UID}
-    command: --HashedControlPassword ${TOR_CONTROL_HASHED_PASSWORD}
     healthcheck:
       test: curl -x socks5h://127.0.0.1:9050 https://check.torproject.org/api/ip | grep -q '"IsTor":true'
       interval: 5m
@@ -106,8 +106,10 @@ services:
     ports:
       - "8332:8332"
     depends_on:
-      - tor-client
-      - i2pd
+      tor-client:
+        condition: service_healthy
+      i2pd:
+        condition: service_started
     restart: always
     init: true
     user: ${UID}

--- a/services/tor-client/Dockerfile
+++ b/services/tor-client/Dockerfile
@@ -59,8 +59,9 @@ RUN apk add --no-cache \
 
 COPY --from=builder /opt/tor/bin/tor  /usr/local/bin/tor
 COPY torrc                            /etc/tor/torrc
+COPY entrypoint.sh                    /usr/local/bin/tor-client-entrypoint
 
 WORKDIR /var/lib/tor
 
 VOLUME ["/var/lib/tor"]
-ENTRYPOINT ["tor", "-f", "/etc/tor/torrc"]
+ENTRYPOINT ["tor-client-entrypoint"]

--- a/services/tor-client/entrypoint.sh
+++ b/services/tor-client/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+: "${TOR_CONTROL_PASSWORD:?TOR_CONTROL_PASSWORD must be set}"
+
+hashed_control_password="$(tor --hash-password "$TOR_CONTROL_PASSWORD" | tail -n 1)"
+
+exec tor -f /etc/tor/torrc --HashedControlPassword "$hashed_control_password" "$@"


### PR DESCRIPTION
Fixes #1

## Summary
- derive the Tor hashed control password at container startup from TOR_CONTROL_PASSWORD
- pass the same TOR_CONTROL_PASSWORD to the Tor client and Knots so onion service authentication cannot drift
- wait for the Tor client healthcheck before starting Knots
- document that the hash is now generated automatically

## Testing
- ruby -e "require 'yaml'; YAML.load_file('docker-compose.yml')"
- sh -n services/tor-client/entrypoint.sh
- git diff --check

Note: I could not run docker compose config locally because Docker is not installed in this environment.